### PR TITLE
Correctly name exported answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Say you have some wonderful elm code, computing sums and storing specific data:
 
 ```elm
 -- src/Main.elm
-module Main exposing (anwser, sum)
+module Main exposing (answer, sum)
 
 answer : Int
 answer = 42


### PR DESCRIPTION

**Quick Summary:** the code example in the README had named `answer` incorrectly
